### PR TITLE
Fix backlink styling and update beta banner example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Collection of 'shiny' application styling that are the based on
 Depends: R (>= 3.1.0)
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 URL: https://github.com/moj-analytical-services/shinyGovstyle
 BugReports: https://github.com/moj-analytical-services/shinyGovstyle/issues
 Imports: 

--- a/R/backlink_Input.R
+++ b/R/backlink_Input.R
@@ -2,6 +2,7 @@
 #'
 #' This function adds a back link to the page
 #' @param inputId The input slot that will be used to access the value.
+#' @param label The link text for the backlink, default is "Back"
 #' @return a backlink html shiny object
 #' @keywords backlink
 #' @export
@@ -42,13 +43,12 @@
 #'   shinyApp(ui = ui, server = server)
 #' }
 
-backlink_Input <- function(inputId) {
+backlink_Input <- function(inputId, label = "Back") {
 
   value <- shiny::restoreInput(id = inputId, default = NULL)
-  govBacklink <- shiny::tags$button("Back",
-                   id = inputId,
-                   class = paste0("govuk-back-link",
-                                  " action-button"),
+  govBacklink <- shiny::actionLink(label = label,
+                   inputId = inputId,
+                   class = paste0("govuk-back-link"),
                    `data-val` = value)
   attachDependency(govBacklink)
 

--- a/R/banner.R
+++ b/R/banner.R
@@ -17,7 +17,7 @@
 #'       secondary_text = "User Examples",
 #'       logo="shinyGovstyle/images/moj_logo.png"),
 #'     shinyGovstyle::banner(
-#'       inputId = "banner", type = "beta", 'This is a new service')
+#'       inputId = "banner", type = "Beta", 'This is a new service')
 #'   )
 #'
 #'   server <- function(input, output, session) {}

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -17,7 +17,7 @@ run_example <- function(){
              logo="shinyGovstyle/images/moj_logo-1.png", logo_width = 66),
       banner(
         "banner",
-        "beta",
+        "Beta",
         'This is a new service \u002D your <a class="govuk-link" href="#">
         feedback</a> will help us to improve it.'),
 

--- a/man/backlink_Input.Rd
+++ b/man/backlink_Input.Rd
@@ -4,10 +4,12 @@
 \alias{backlink_Input}
 \title{Back Link Function}
 \usage{
-backlink_Input(inputId)
+backlink_Input(inputId, label = "Back")
 }
 \arguments{
 \item{inputId}{The input slot that will be used to access the value.}
+
+\item{label}{The link text for the backlink, default is "Back"}
 }
 \value{
 a backlink html shiny object

--- a/man/banner.Rd
+++ b/man/banner.Rd
@@ -29,7 +29,7 @@ if (interactive()) {
       secondary_text = "User Examples",
       logo="shinyGovstyle/images/moj_logo.png"),
     shinyGovstyle::banner(
-      inputId = "banner", type = "beta", 'This is a new service')
+      inputId = "banner", type = "Beta", 'This is a new service')
   )
 
   server <- function(input, output, session) {}

--- a/tests/testthat/test-backlink_Input.R
+++ b/tests/testthat/test-backlink_Input.R
@@ -2,7 +2,7 @@ test_that("backlink works", {
   backlink_check <- backlink_Input("backId")
 
   expect_identical(
-    backlink_check$children[[1]],
+    backlink_check$children[[1]][[2]],
     "Back"
   )
 


### PR DESCRIPTION
### Overview

After updating the CSS to v5.4 the backlink wasn't styling right and the tag in the beta banner now looked a bit odd as it's now longer defaulting to all caps.

### Backlink

I changed this to an action link instead, which seemed to help it pick up the styling. I tested on the example app and functionality did seem to work fine, though the tests were failing as the placing of the label within the underlying object had moved - so I've updated them to match the updates to the function.

I also added a `label` argument so that people can customise the label if they want, though left the default as "Back", so in theory it stays backwards compatible.

Before:
![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/52536248/613e1d82-00b2-4724-9542-8f5e394cc479)

After:
![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/52536248/4bd125ee-2ccd-4181-99a5-8c4e0e4d379c)

### Beta banner

This was a quick one to update the case in the examples to be in line with updated GDS tag component

Before:
![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/52536248/dfa53f6d-dc1e-4743-9a94-bdc3c9261a3e)

After:
![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/52536248/6cf5982a-4e22-4c13-b046-8408e085444a)


### Documentation

I had a newer version of roxygen2 locally so updated the package to that to then update the docs, assuming this hasn't caused any issues?
