### PR TITLE
Fix small size of header

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -70,7 +70,7 @@ header <- function(main_text, secondary_text, logo = NULL,
       shiny::tags$div(class = "govuk-header__content",
         shiny::tags$a(
           href = secondary_link, secondary_text,
-          class = "govuk-header__link govuk-header__link--service-name"
+          class = "govuk-header__link govuk-header__service-name"
         )
       )
     )


### PR DESCRIPTION
Previously looked like this where the header text was too small ![Screenshot 2024-06-05 at 15 23 34](https://github.com/moj-analytical-services/shinyGovstyle/assets/75032474/87b0ad86-eaa2-424f-baea-0f25bfacbd9c)

Was pointing to old css element that has now been renamed.

Updated here:
![Screenshot 2024-06-05 at 15 26 30](https://github.com/moj-analytical-services/shinyGovstyle/assets/75032474/1bfafb1a-48af-4776-941d-c5388f359455)


