### PR TITLE
Remove "warning" from appearing where it shouldn't

### DIFF
--- a/R/warning_text.R
+++ b/R/warning_text.R
@@ -31,7 +31,7 @@ warning_text <- function(inputId, text){
       "!", class="govuk-warning-text__icon", `aria-hidden`="true"
     ),
     shiny::tags$strong(text, class="govuk-warning-text__text",
-      shiny::tags$span("Warning", class="govuk-warning-text__assistive")
+      shiny::tags$span("Warning", class="govuk-visually-hidden")
     )
   )
   attachDependency(govWarning)


### PR DESCRIPTION
Overhang from old CSS and use of `.govuk-warning-text__assistive` which is no longer in CSS file. Printed out "Warning" in text after every warning message:
![Screenshot 2024-06-05 at 15 48 59](https://github.com/moj-analytical-services/shinyGovstyle/assets/75032474/f59ffe82-c1ec-4853-a6e1-8285de0d54b7)

Now uses `govuk-visually-hidden` - checked and this is a lift and shift of the old assistive text CSS, with a few more custom options for users added in (think this is to support different assistive setups)
![Screenshot 2024-06-05 at 15 47 20](https://github.com/moj-analytical-services/shinyGovstyle/assets/75032474/b1a335d3-b3e3-4da5-92ca-57b3893363c0)
