### PR TITLE
Cookie link update

### DIFF
--- a/R/cookieBanner.R
+++ b/R/cookieBanner.R
@@ -43,7 +43,7 @@
 #'   })
 #'
 #'   observeEvent(input$cookieLink, {
-#'     #Need to link here to where further info is located.  You can you
+#'     #Need to link here to where further info is located.  You can use
 #'     #updateTabsetPanel to have a cookie page for instance
 #'   })
 #'
@@ -54,11 +54,10 @@
 cookieBanner <- function(service_name) {
 
   value <- shiny::restoreInput(id = "cookieLink", default = NULL)
-  govCookieLink <- shiny::tags$button(
-    "View cookies",
-    id = "cookieLink",
-    class = paste0("govuk-link", " action-button"),
-    `data-val` = value)
+  govCookieLink <- shiny::actionLink(
+    inputId = "cookieLink",
+    label = "View cookies",
+    class = "govuk-link")
 
   attachDependency(govCookieLink)
 

--- a/R/cookieBanner.R
+++ b/R/cookieBanner.R
@@ -53,14 +53,10 @@
 
 cookieBanner <- function(service_name) {
 
-  value <- shiny::restoreInput(id = "cookieLink", default = NULL)
   govCookieLink <- shiny::actionLink(
     inputId = "cookieLink",
     label = "View cookies",
-    class = "govuk-link",
-    `data-val` = value)
-
-  attachDependency(govCookieLink)
+    class = "govuk-link")
 
   cookieBanner_Input <-
     shiny::tags$div(

--- a/R/cookieBanner.R
+++ b/R/cookieBanner.R
@@ -57,7 +57,8 @@ cookieBanner <- function(service_name) {
   govCookieLink <- shiny::actionLink(
     inputId = "cookieLink",
     label = "View cookies",
-    class = "govuk-link")
+    class = "govuk-link",
+    `data-val` = value)
 
   attachDependency(govCookieLink)
 


### PR DESCRIPTION
Change the View cookies link in the cookie banner from a `shiny::tags$button` to `shiny::actionLink`. Removed lines that I _think_ were unnecessary as `value` is not used and the link actually functions from an `observeEvent` in the server already anyway, which I have kept and still continues to function in the same way. 