### PR TITLE
revert footer css link to what it was before when it worked!

### DIFF
--- a/css_changes.md
+++ b/css_changes.md
@@ -24,7 +24,7 @@ color: #0b0c0c;
 ```
 
 * Move fonts css to the font css
-*Change url links
+* Change url links
 
 * For accordion need to fix the norem by:
 ```
@@ -44,5 +44,28 @@ color: #0b0c0c;
 
 .js-enabled .govuk-accordion__section-toggle {
   pointer-events: none;
+}
+```
+
+* Change filepaths for crown copyright logo:
+```
+.govuk-footer__copyright-logo {
+    display: inline-block;
+    min-width: 125px;
+    padding-top: 112px;
+    background-image: url(../images/govuk-crest.png);
+    background-repeat: no-repeat;
+    background-position: 50% 0;
+    background-size: 125px 102px;
+    text-align: center;
+    white-space: nowrap
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:2),
+only screen and (min-resolution:192dpi),
+only screen and (min-resolution:2dppx) {
+    .govuk-footer__copyright-logo {
+        background-image: url(../images/govuk-crest-2x.png)
+    }
 }
 ```

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -3516,7 +3516,7 @@ screen and (forced-colors:active) {
     display: inline-block;
     min-width: 125px;
     padding-top: 112px;
-    background-image: url(/assets/images/govuk-crest.png);
+    background-image: url(../images/govuk-crest.png);
     background-repeat: no-repeat;
     background-position: 50% 0;
     background-size: 125px 102px;
@@ -3528,7 +3528,7 @@ screen and (forced-colors:active) {
 only screen and (min-resolution:192dpi),
 only screen and (min-resolution:2dppx) {
     .govuk-footer__copyright-logo {
-        background-image: url(/assets/images/govuk-crest-2x.png)
+        background-image: url(../images/govuk-crest-2x.png)
     }
 }
 


### PR DESCRIPTION
In one of @cjrace commits, the link to the crown copyright logo in the CSS file had been changed and was no longer working. Reverting back to the original link has fixed this. 