### PR TITLE
Gov summary

### DIFF
--- a/R/run_example.R
+++ b/R/run_example.R
@@ -159,7 +159,7 @@ run_example <- function(){
               body_txt = "You have 7 days left to send your application.",
               type = "standard"
             ),
-
+            heading_text("gov_summary", size = "s"),
             shinyGovstyle::gov_summary(
               "sumID",
               c("Name", "Date of birth", "Contact information", "Contact details"),

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -158,7 +158,21 @@ run_example <- function(){
               title_txt = "Important",
               body_txt = "You have 7 days left to send your application.",
               type = "standard"
-            )
+            ),
+
+            shinyGovstyle::gov_summary(
+              "sumID",
+              c("Name", "Date of birth", "Contact information", "Contact details"),
+              c(
+                "Sarah Philips",
+                "5 January 1978",
+                "72 Guild Street <br> London <br> SE23 6FH",
+                "07700 900457 <br> sarah.phillips@example.com"
+              ),
+              action = FALSE
+            ),
+
+
           )
         ),
 


### PR DESCRIPTION
Added **gov_summary** to the **run_example** function at the bottom of the Feedback page - 

![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/166698885/bce567bf-c757-471a-909b-cbce3af88884)

**Issue** - words split when wrapping across smaller screen sizes

![image](https://github.com/moj-analytical-services/shinyGovstyle/assets/166698885/2c559c82-f4af-4167-a4d3-4398e959fbf0)
