### PR TITLE
Updated alignment of radio button item labels

### DIFF
--- a/R/run_example.R
+++ b/R/run_example.R
@@ -45,10 +45,16 @@ run_example <- function(){
             heading_text("Page 1", size = "l"),
             label_hint("label1", "These are some examples of the types of user
                    select type inputs that you can use"),
-            heading_text("radio_button_Input", size = "s"),
+            heading_text("radio_button_Input (inline)", size = "s"),
             radio_button_Input(
               inputId = "name_changed", label = "Have you changed your name?",
               choices = c("Yes", "No"), inline = TRUE,
+              hint_label = "This includes changing your last name or spelling
+                            your name differently."),
+            heading_text("radio_button_Input (stacked)", size = "s"),
+            radio_button_Input(
+              inputId = "name_changed", label = "Have you changed your name?",
+              choices = c("Yes", "No"), inline = FALSE,
               hint_label = "This includes changing your last name or spelling
                             your name differently."),
             heading_text("checkbox_Input", size = "s"),

--- a/css_changes.md
+++ b/css_changes.md
@@ -69,3 +69,25 @@ only screen and (min-resolution:2dppx) {
     }
 }
 ```
+
+* Fix alignment on the radio button item labels
+```
+.govuk-radios__input {
+    z-index: 1;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    opacity: 0;
+    vertical-align: middle;
+    cursor: pointer
+}
+
+.govuk-radios__label {
+    align-self: center;
+    max-width: calc(100% - 74px);
+    display: inline-block;
+    padding: 7px 15px;
+    cursor: pointer;
+    touch-action: manipulation
+}
+```

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -4842,14 +4842,15 @@ only screen and (min-resolution:2dppx) {
     height: 44px;
     margin: 0;
     opacity: 0;
+    vertical-align: middle;
     cursor: pointer
 }
 
 .govuk-radios__label {
     align-self: center;
     max-width: calc(100% - 74px);
-    margin-bottom: 0;
-    padding: 7px 15px;
+    display: inline-block;
+    padding: 8px 15px 5px;
     cursor: pointer;
     touch-action: manipulation
 }

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -4850,7 +4850,7 @@ only screen and (min-resolution:2dppx) {
     align-self: center;
     max-width: calc(100% - 74px);
     display: inline-block;
-    padding: 8px 15px 5px;
+    padding: 7px 15px;
     cursor: pointer;
     touch-action: manipulation
 }


### PR DESCRIPTION
This should be more in line with what was asked for. I've set the alignment properly now so that radio button item labels are centre aligned vertically with their parent radio button.

The screenshot below shows what it looks like now after some small css tweaks:

<img width="456" alt="image" src="https://github.com/moj-analytical-services/shinyGovstyle/assets/230859/819d1dc5-719f-40d0-b3d1-fa8528fe0fc5">

Note that I've also added an extra check into the run_example() code as I don't think the stacked radio items were aligning properly previously either and I wanted to see both in action.

