### PR TITLE
Updating file upload to be consistent with GDS

### DIFF
--- a/R/file_Input.R
+++ b/R/file_Input.R
@@ -107,17 +107,7 @@ file_Input <- function(inputId, label, multiple = FALSE, accept = NULL,
         )
       },
 
-      shiny::div(id = paste0(inputId,"file_div"), class = "input-group",
-          shiny::tags$label(class = "input-group-btn",
-                     shiny::span(class = "btn btn-default btn-file",
-                          buttonLabel,
-                          inputTag
-                     )
-          ),
-          shiny::tags$input(type = "text", class = "form-control",
-                     placeholder = placeholder, readonly = "readonly"
-          )
-      )
+      shiny::tags$input(class = "govuk-file-upload", id = inputId, type = "file")
   )
   attachDependency(govFile)
 }

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -3305,11 +3305,12 @@ screen and (forced-colors:active) {
     -moz-osx-font-smoothing: grayscale;
     font-weight: 400;
     font-size: 1rem;
-    line-height: 1.25;
+    line-height: 1.25 !important;
     color: #0b0c0c;
     max-width: 100%;
     margin-left: -5px;
-    padding: 5px
+    padding: 6px !important;
+    font-size: 14pt;
 }
 
 @media print {
@@ -3340,13 +3341,13 @@ screen and (forced-colors:active) {
 }
 
 .govuk-file-upload:focus {
-    outline: 3px solid #fd0;
-    box-shadow: inset 0 0 0 4px #0b0c0c
+    outline: 3px solid #fd0 !important;
+    box-shadow: inset 0 0 0 5px #0b0c0c !important
 }
 
 .govuk-file-upload:focus-within {
-    outline: 3px solid #fd0;
-    box-shadow: inset 0 0 0 4px #0b0c0c
+    outline: 3px solid #fd0 !important;
+    box-shadow: inset 0 0 0 5px #0b0c0c !important
 }
 
 .govuk-file-upload:disabled {


### PR DESCRIPTION
## Some notes on this one

The reason that it's not picking up the GDS styling is that shiny implements it's own tailored upload input that's different from the standard html method that the GDS assumes:

### Shiny
```
      shiny::tags$label(label, class="govuk-label"),
      shiny::div(id = paste0(inputId,"file_div"), class = "input-group",
          shiny::tags$label(class = "input-group-btn",
                     shiny::span(class = "btn btn-default btn-file",
                          buttonLabel,
                          inputTag
                     )
          ),
          shiny::tags$input(type = "text", class = "form-control",
                     placeholder = placeholder, readonly = "readonly"
          )
      )
```
You can see that uses the css hierarchical classes `input-group`, `input-group-btn`, `btn`, `btn-default`, `btn-file` and `form-control`. These are all standard in [bootstrap.css](https://github.com/rstudio/shiny/blob/v1.8.1/inst/www/shared/bootstrap/css/bootstrap.css).

### [GDS](https://design-system.service.gov.uk/components/file-upload/)

The GDS html method would translate to something like the following using `htmltools::tags()`:

```
      shiny::tags$label(label, class="govuk-label"),
      shiny::tags$input(class = "govuk-file-upload", id="inputId", type="file")
```

So the elements to be styled are just different types of things - Shiny creates it's own button and text input, whilst GDS assumes the standard file upload html input. So it either needs some entirely new css writing I think or the file upload function overhauling to use the tag `input(...,file="type")`.