### PR TITLE
govTabs gds54 update

### DIFF
--- a/R/govTabs.R
+++ b/R/govTabs.R
@@ -64,7 +64,7 @@ govTabs <- function(inputId, df, group_col) {
 
 
   #Put the lime with coconut and create the final thing
-  main_tab_div <- shiny::tags$div(class = "js-enabled",
+  main_tab_div <- shiny::tags$div(class = "govuk-frontend-supported",
     shiny::tags$h2(class = "govuk-tabs__title", "Contents"),
     tab_headers,
     main_temp_hold)

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -138,7 +138,7 @@ run_example <- function(){
           value = "panel3",
           gov_layout(
             size = "two-thirds",
-            backlink_Input("back1"),
+            backlink_Input("back2"),
             heading_text("Page 3", size = "l"),
             label_hint("label3", "These are some examples of using tabs and
                        tables"),
@@ -147,7 +147,9 @@ run_example <- function(){
               "tab1", example_data, "Test", "l", num_col = c(2,3),
               width_overwrite = c("one-half", "one-quarter", "one-quarter")),
             heading_text("govTabs", size = "s"),
-            shinyGovstyle::govTabs("tabsID", data, "tabs")
+            shinyGovstyle::govTabs("tabsID", data, "tabs"),
+            heading_text("button_Input", size = "s"),
+            button_Input("btn4", "Go to next page"),
           )
         ),
 
@@ -157,7 +159,7 @@ run_example <- function(){
           value = "panel-feedback",
           gov_layout(
             size = "two-thirds",
-            backlink_Input("back2"),
+            backlink_Input("back3"),
             heading_text("Feedback page", size = "l"),
             label_hint("label-feedback", "These are some examples of the types of user
                    feedback inputs that you can use"),
@@ -253,6 +255,12 @@ run_example <- function(){
                         selected = "panel3")
     })
 
+    # Nav to next tab
+    shiny::observeEvent(input$btn4, {
+      shiny::updateTabsetPanel(session, "nav",
+                               selected = "panel-feedback")
+    })
+
     shiny::observeEvent(input$back1, {
       shiny::updateTabsetPanel(session, "nav",
                                selected = "panel1")
@@ -263,6 +271,10 @@ run_example <- function(){
                                selected = "panel2")
     })
 
+    shiny::observeEvent(input$back3, {
+      shiny::updateTabsetPanel(session, "nav",
+                               selected = "panel3")
+    })
 
     # Need this to use live update the word counter
     shiny::observeEvent(

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -10,8 +10,8 @@
 #'}
 run_example <- function(){
   Months <- c("January", "February", "March")
-  Bikes <- c("£85", "£75", "£165")
-  Cars <- c("£95", "£55", "£125")
+  Bikes <- c(85, 75, 165)
+  Cars <- c(95, 55, 125)
   example_data <- data.frame(Months, Bikes, Cars)
   tabs <- c(rep("Past Day", 3),
             rep("Past Week", 3),

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -9,6 +9,19 @@
 #' run_example()
 #'}
 run_example <- function(){
+  Months <- c("January", "February", "March")
+  Bikes <- c("£85", "£75", "£165")
+  Cars <- c("£95", "£55", "£125")
+  example_data <- data.frame(Months, Bikes, Cars)
+  tabs <- c(rep("Past Day", 3),
+            rep("Past Week", 3),
+            rep("Past Month", 3),
+            rep("Past Year", 3))
+  Case_manager <- rep(c("David Francis", "Paul Farmer", "Rita Patel"),4)
+  Cases_open <- c(3, 1, 2, 24, 16, 24, 98, 122, 126, 1380, 1129, 1539)
+  Cases_closed <- c(0, 0, 0, 18, 20, 27, 95, 131, 142, 1472, 1083, 1265)
+  data <- data.frame(tabs, Case_manager, Cases_open, Cases_closed)
+
   shiny::shinyApp(
     ui = shiny::fluidPage(
       title="ShinyGovstyle",
@@ -116,6 +129,25 @@ run_example <- function(){
             heading_text("button_Input", size = "s"),
             button_Input("btn2", "Go to next page"),
             button_Input("btn3", "Check for errors", type = "warning")
+          )
+        ),
+
+        #####################Create third panel################################
+        shiny::tabPanel(
+          "Table",
+          value = "panel3",
+          gov_layout(
+            size = "two-thirds",
+            backlink_Input("back1"),
+            heading_text("Page 3", size = "l"),
+            label_hint("label3", "These are some examples of the types of user
+                   text inputs that you can use"),
+            heading_text("govTable", size = "s"),
+            shinyGovstyle::govTable(
+              "tab1", example_data, "Test", "l", num_col = c(2,3),
+              width_overwrite = c("one-half", "one-quarter", "one-quarter")),
+            heading_text("govTabs", size = "s"),
+            shinyGovstyle::govTabs("tabsID", data, "tabs")
           )
         ),
 

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -140,8 +140,8 @@ run_example <- function(){
             size = "two-thirds",
             backlink_Input("back1"),
             heading_text("Page 3", size = "l"),
-            label_hint("label3", "These are some examples of the types of user
-                   text inputs that you can use"),
+            label_hint("label3", "These are some examples of using tabs and
+                       tables"),
             heading_text("govTable", size = "s"),
             shinyGovstyle::govTable(
               "tab1", example_data, "Test", "l", num_col = c(2,3),
@@ -151,15 +151,15 @@ run_example <- function(){
           )
         ),
 
-        #####################Create third panel################################
+        #####################Create feedback panel################################
         shiny::tabPanel(
           "Feedback Types",
-          value = "panel3",
+          value = "panel-feedback",
           gov_layout(
             size = "two-thirds",
             backlink_Input("back2"),
-            heading_text("Page 3", size = "l"),
-            label_hint("label3", "These are some examples of the types of user
+            heading_text("Feedback page", size = "l"),
+            label_hint("label-feedback", "These are some examples of the types of user
                    feedback inputs that you can use"),
             heading_text("tag_Input", size = "s"),
 
@@ -225,14 +225,14 @@ run_example <- function(){
           )
         ),
 
-        #####################Create fourth panel################################
+        #####################Create cookie panel################################
         shiny::tabPanel(
           "Cookies",
-          value = "panel4",
+          value = "panel-cookies",
           gov_layout(
             size = "two-thirds",
-            heading_text("Page 3", size = "l"),
-            label_hint("label3", "This an example cookie page that could be
+            heading_text("Cookie page", size = "l"),
+            label_hint("label-cookies", "This an example cookie page that could be
                        expanded")
           )
         )),

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -134,7 +134,7 @@ run_example <- function(){
 
         #####################Create third panel################################
         shiny::tabPanel(
-          "Table",
+          "Tables and tabs",
           value = "panel3",
           gov_layout(
             size = "two-thirds",

--- a/css_changes.md
+++ b/css_changes.md
@@ -91,3 +91,17 @@ only screen and (min-resolution:2dppx) {
     touch-action: manipulation
 }
 ```
+
+* Fix selected tab panel border gap
+```
+.govuk-frontend-supported .govuk-tabs__list-item--selected {
+    position: relative;
+    margin-top: -5px;
+    margin-bottom: -2px;
+    padding: 14px 19px 16px;
+    border: 1px solid #b1b4b6;
+    border-bottom: none;
+    background-color: #fff
+}
+```
+

--- a/css_changes.md
+++ b/css_changes.md
@@ -105,3 +105,13 @@ only screen and (min-resolution:2dppx) {
 }
 ```
 
+* govTable caption colour:
+
+```
+.govuk-table__caption {
+    font-weight: 700;
+    display: table-caption;
+    text-align: left;
+    color: #000;
+}
+```

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -5650,7 +5650,8 @@ screen and (-ms-high-contrast:active) {
 .govuk-table__caption {
     font-weight: 700;
     display: table-caption;
-    text-align: left
+    text-align: left;
+    color: #000;
 }
 
 .govuk-table__caption--l,

--- a/inst/www/css/govuk-frontend-norem.css
+++ b/inst/www/css/govuk-frontend-norem.css
@@ -5898,10 +5898,10 @@ screen and (-ms-high-contrast:active) {
     .govuk-frontend-supported .govuk-tabs__list-item--selected {
         position: relative;
         margin-top: -5px;
-        margin-bottom: -1px;
+        margin-bottom: -2px;
         padding: 14px 19px 16px;
         border: 1px solid #b1b4b6;
-        border-bottom: 0;
+        border-bottom: none;
         background-color: #fff
     }
 


### PR DESCRIPTION
## Main edits

govTabs weren't rendering properly, so this is a quick update to the css to get them back on track:

- The class previously was .js-enabled, but this seems to have switched to .govuk-frontend-supported now. I've updated all instances of `js-enabled` as the class in the R code for `govTabs to govuk-frontend-supported`
- To force a gap in the border between the tab label and the tab for the selected tab, the previous css used a -1px bottom margin to shift the label border to override the tab border. To get the same effect now needs a margin of -2px. Bit random (i.e. I don't know why it's -2px rather than -1px now), but seems to work.

## Other edits

I've added `govTable` and `govTabs` examples to the example dashboard run using `run_example()`