### PR TITLE
Allow footer links

### DIFF
--- a/R/footer.R
+++ b/R/footer.R
@@ -65,7 +65,7 @@ footer <- function(full = FALSE, links = NULL) {
           shiny::div(
             class = "govuk-footer__meta-item govuk-footer__meta-item--grow",
             if (!is.null(links)) {
-              div(
+              shiny::div(
                 # Set a visually hidden title for accessibility
                 shiny::h2(
                   class = "govuk-visually-hidden",
@@ -84,6 +84,21 @@ footer <- function(full = FALSE, links = NULL) {
           shiny::tagList(
             shiny::div(
               class = "govuk-footer__meta-item govuk-footer__meta-item--grow",
+              if (!is.null(links)) {
+                shiny::div(
+                  # Set a visually hidden title for accessibility
+                  shiny::h2(
+                    class = "govuk-visually-hidden",
+                    "Support links"
+                  ),
+                  shiny::tags$ul(
+                    class = "govuk-footer__inline-list",
+
+                    # Generate as many links as needed
+                    lapply(links, footer_link)
+                  )
+                )
+              },
               shiny::tag("svg", list(
                 role = "presentation",
                 focusable = "false",

--- a/R/footer.R
+++ b/R/footer.R
@@ -34,7 +34,7 @@
 #'   shinyApp(ui = ui, server = server)
 #' }
 #'
-#' footer(links_list = c("Footnotes", "Support", "Accessibility statement", "Cookies"))
+#' footer(links = c("Accessibility statement", "Cookies"))
 footer <- function(full = FALSE, links = NULL) {
   # Validation on the links input
   if (!is.null(links)) {

--- a/R/footer.R
+++ b/R/footer.R
@@ -1,21 +1,29 @@
 #' Footer Function
 #'
 #' This function create a gov style footer for your page
+#'
+#' You can add actionLinks as links in the footer through using the links_list
+#' argument.
+#'
 #' @param full Whenever you want to have blank footer or official gov version.
 #' Defaults to \code{FALSE}
+#' @param links A vector of actionLinks to be added to the footer, inputIDs
+#' are auto-generated and are the snake case version of the link text, e.g.
+#' "Accessibility Statement" will have an inputID of accessibility_statement
 #' @return a footer html shiny object
 #' @keywords footer
 #' @export
 #' @examples
 #' if (interactive()) {
-#'
 #'   ui <- fluidPage(
 #'     shinyGovstyle::header(
 #'       main_text = "Example",
 #'       secondary_text = "User Examples",
-#'       logo="shinyGovstyle/images/moj_logo.png"),
+#'       logo = "shinyGovstyle/images/moj_logo.png"
+#'     ),
 #'     shinyGovstyle::banner(
-#'       inputId = "banner", type = "beta", 'This is a new service'),
+#'       inputId = "banner", type = "beta", "This is a new service"
+#'     ),
 #'     tags$br(),
 #'     tags$br(),
 #'     shinyGovstyle::footer(full = TRUE)
@@ -25,62 +33,105 @@
 #'
 #'   shinyApp(ui = ui, server = server)
 #' }
+#'
+#' footer(links_list = c("Footnotes", "Support", "Accessibility statement", "Cookies"))
+footer <- function(full = FALSE, links = NULL) {
+  # Validation on the links input
+  if (!is.null(links)) {
+    if (!is.vector(links)) {
+      stop("links must be a vector")
+    }
 
-footer <- function(full = FALSE){
-  govFooter <- shiny::tags$footer(class = "govuk-footer ",
+    footer_link <- function(link_text) {
+      shiny::tags$li(
+        class = "govuk-footer__inline-list-item",
+        shiny::actionLink(
+          class = "govuk-link govuk-footer__link",
+          inputId = tolower(gsub(" ", "_", link_text)),
+          label = link_text
+        )
+      )
+    }
+  }
+
+  # The HTML div to be returned
+  govFooter <- shiny::tags$footer(
+    class = "govuk-footer ",
     role = "contentinfo",
-    shiny::div(class = "govuk-width-container ",
-      shiny::div(class = "govuk-footer__meta",
-        if (full==FALSE){
-          shiny::div(
-            class = "govuk-footer__meta-item govuk-footer__meta-item--grow")
-        }
-        else {
-          shiny::tagList(
+    shiny::div(
+      class = "govuk-width-container ",
+      shiny::div(
+        if (full == FALSE) {
           shiny::div(
             class = "govuk-footer__meta-item govuk-footer__meta-item--grow",
-            shiny::tag("svg", list(
-              role = "presentation",
-              focusable = "false",
-              class = "govuk-footer__licence-logo",
-              xmlns = "http://www.w3.org/2000/svg",
-              viewbox = "0 0 483.2 195.7",
-              height = "17",
-              width = "41",
-              shiny::tag("path", list(fill = "currentColor",
-                  d = paste0("M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7",
-                             "zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21",
-                             ".1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7",
-                             "-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1",
-                             "-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97",
-                             ".8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.",
-                             "7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8",
-                             "h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47",
-                             ".1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145",
-                             " 97.8 145")
-              )))
+            if (!is.null(links)) {
+              div(
+                # Set a visually hidden title for accessibility
+                shiny::h2(
+                  class = "govuk-visually-hidden",
+                  "Support links"
                 ),
-              shiny::tags$span(class = "govuk-footer__licence-description",
+                shiny::tags$ul(
+                  class = "govuk-footer__inline-list",
+
+                  # Generate as many links as needed
+                  lapply(links, footer_link)
+                )
+              )
+            }
+          )
+        } else {
+          shiny::tagList(
+            shiny::div(
+              class = "govuk-footer__meta-item govuk-footer__meta-item--grow",
+              shiny::tag("svg", list(
+                role = "presentation",
+                focusable = "false",
+                class = "govuk-footer__licence-logo",
+                xmlns = "http://www.w3.org/2000/svg",
+                viewbox = "0 0 483.2 195.7",
+                height = "17",
+                width = "41",
+                shiny::tag("path", list(
+                  fill = "currentColor",
+                  d = paste0(
+                    "M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7",
+                    "zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21",
+                    ".1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7",
+                    "-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1",
+                    "-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97",
+                    ".8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.",
+                    "7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8",
+                    "h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47",
+                    ".1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145",
+                    " 97.8 145"
+                  )
+                ))
+              )),
+              shiny::tags$span(
+                class = "govuk-footer__licence-description",
                 "All content is available under the",
-                shiny::tags$a(class = "govuk-footer__link",
+                shiny::tags$a(
+                  class = "govuk-footer__link",
                   href = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
                   rel = "license",
-                  "Open Government Licence v3.0"),
-                  ", except where otherwise stated")),
-                shiny::tags$div(class = "govuk-footer__meta-item",
-                  shiny::tags$a(
-                    class = "govuk-footer__link govuk-footer__copyright-logo",
-                    href = "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/",
-                    "\u00A9 Crown copyright"
-                  )
-
-                ))
-
+                  "Open Government Licence v3.0"
+                ),
+                ", except where otherwise stated"
+              )
+            ),
+            shiny::tags$div(
+              class = "govuk-footer__meta-item",
+              shiny::tags$a(
+                class = "govuk-footer__link govuk-footer__copyright-logo",
+                href = "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/",
+                "\u00A9 Crown copyright"
+              )
+            )
+          )
         }
       )
     )
   )
   attachDependency(govFooter)
 }
-
-

--- a/R/run_example.R
+++ b/R/run_example.R
@@ -357,7 +357,7 @@ shiny::column( width = 9,
 
 ), #end of gov row
 
-    footer(TRUE)
+    footer(TRUE, links = c("Cookies"))
 
 
 ), #end of fluid page
@@ -383,6 +383,10 @@ shiny::column( width = 9,
     })
 
     shiny::observeEvent(input$cookies_button, {
+      shiny::updateTabsetPanel(session, "tab-container", selected = "panel-cookies")
+    })
+
+    shiny::observeEvent(input$cookies, {
       shiny::updateTabsetPanel(session, "tab-container", selected = "panel-cookies")
     })
 

--- a/man/footer.Rd
+++ b/man/footer.Rd
@@ -10,8 +10,8 @@ footer(full = FALSE, links = NULL)
 \item{full}{Whenever you want to have blank footer or official gov version.
 Defaults to \code{FALSE}}
 
-\item{links_list}{A list of actionLinks to be added to the footer, inputIDs
-are auto-generated and are the  snake case version of the link text, e.g.
+\item{links}{A vector of actionLinks to be added to the footer, inputIDs
+are auto-generated and are the snake case version of the link text, e.g.
 "Accessibility Statement" will have an inputID of accessibility_statement}
 }
 \value{
@@ -45,6 +45,6 @@ if (interactive()) {
   shinyApp(ui = ui, server = server)
 }
 
-footer(links_list = c("Footnotes", "Support", "Accessibility statement", "Cookies"))
+footer(links = c("Accessibility statement", "Cookies"))
 }
 \keyword{footer}

--- a/man/footer.Rd
+++ b/man/footer.Rd
@@ -4,11 +4,15 @@
 \alias{footer}
 \title{Footer Function}
 \usage{
-footer(full = FALSE)
+footer(full = FALSE, links = NULL)
 }
 \arguments{
 \item{full}{Whenever you want to have blank footer or official gov version.
 Defaults to \code{FALSE}}
+
+\item{links_list}{A list of actionLinks to be added to the footer, inputIDs
+are auto-generated and are the  snake case version of the link text, e.g.
+"Accessibility Statement" will have an inputID of accessibility_statement}
 }
 \value{
 a footer html shiny object
@@ -16,16 +20,21 @@ a footer html shiny object
 \description{
 This function create a gov style footer for your page
 }
+\details{
+You can add actionLinks as links in the footer through using the links_list
+argument.
+}
 \examples{
 if (interactive()) {
-
   ui <- fluidPage(
     shinyGovstyle::header(
       main_text = "Example",
       secondary_text = "User Examples",
-      logo="shinyGovstyle/images/moj_logo.png"),
+      logo = "shinyGovstyle/images/moj_logo.png"
+    ),
     shinyGovstyle::banner(
-      inputId = "banner", type = "beta", 'This is a new service'),
+      inputId = "banner", type = "beta", "This is a new service"
+    ),
     tags$br(),
     tags$br(),
     shinyGovstyle::footer(full = TRUE)
@@ -35,5 +44,7 @@ if (interactive()) {
 
   shinyApp(ui = ui, server = server)
 }
+
+footer(links_list = c("Footnotes", "Support", "Accessibility statement", "Cookies"))
 }
 \keyword{footer}

--- a/tests/testthat/test-footer.R
+++ b/tests/testthat/test-footer.R
@@ -1,21 +1,48 @@
 test_that("test default footer", {
-
   footer_check <- footer()
 
   expect_identical(
     footer_check$attribs$class,
     "govuk-footer "
   )
-
 })
 
 test_that("test default footer", {
-
   footer_check <- footer(TRUE)
 
   expect_identical(
     footer_check$attribs$class,
     "govuk-footer "
   )
+})
 
+test_that("footer links add correctly", {
+  footer_with_links <- footer(
+    links = c("Accessibility Statement", "Cookies")
+  ) |>
+    paste0()
+
+  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"accessibility_statement\">Accessibility Statement</a>'
+  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
+
+  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"cookies\">Cookies</a>'
+  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
+
+  expected_html <- '<h2 class=\"govuk-visually-hidden\">Support links</h2>\n          <ul class=\"govuk-footer__inline-list\">\n            <li class=\"govuk-footer__inline-list-item\">'
+  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
+
+  full_footer_with_links <- footer(
+    TRUE,
+    c("Privacy Notice", "Cookies")
+  ) |>
+    paste0()
+
+  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"privacy_notice\">Privacy Notice</a>'
+  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
+
+  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"cookies\">Cookies</a>'
+  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
+
+  expected_html <- '<h2 class=\"govuk-visually-hidden\">Support links</h2>\n          <ul class=\"govuk-footer__inline-list\">\n            <li class=\"govuk-footer__inline-list-item\">'
+  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
 })

--- a/tests/testthat/test-radio_button_input.R
+++ b/tests/testthat/test-radio_button_input.R
@@ -1,6 +1,3 @@
-
-library("shiny")
-
 test_that("Default", {
 
   choices <- c("A", "B", "C")

--- a/tests/testthat/test-run_example.R
+++ b/tests/testthat/test-run_example.R
@@ -1,4 +1,3 @@
-
 test_that("shiny example loads", {
   shiny::testServer(
     app = run_example(), {


### PR DESCRIPTION
## Overview of changes

Resolves #77, by adding an extra argument to the footer, allowing a vector of link text to be added, automatically generating actionLinks and IDs that can be used to control a hidden tabset.

Gone for this approach as I think it balances simplicity for the users with the functional need. As R Shiny is almost always a single page app, I assume most people would be using actionLinks to trigger a tabset shifting rather than actual href's to external pages. If we think this is a need, then I'll need to think again about the argument users can use. An alternative could be to allow users to put in any shiny tagList they deem appropriate, would be easier for us but then opens the door to more weird and wonderful stuff that might not be ideal or have the right styling.

Have added a functional example to the `run_example()` app too.

![image](https://github.com/user-attachments/assets/402f9f82-791d-4e80-92bd-2a2da9c557e5)

## PR Checklist

- [x] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

1. Does it work as you'd expect?
2. Is the documentation intuitive to follow?
3. Is there enough test coverage?
4. Should we be allowing standard anchor links in this as well? (if so, then probably best to do that now before merging)
5. Do we still need the `full = TRUE / FALSE` option? Having poke at it a bit, I can see difference in the output code, but can't work out the difference for an end user of a dashboard? If we don't, I could try to tidy that up in this PR too?
6. Should the crown symbol be on the right? Just noticed in my screenshot it wraps underneath, which feels odd, that wasn't something I've consciously done! 